### PR TITLE
Fix (render): Resolve deployment errors on Render

### DIFF
--- a/career_recommendation_system/settings.py
+++ b/career_recommendation_system/settings.py
@@ -131,7 +131,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 SECRET_KEY = 'replace-with-your-secret-key'
 DEBUG = True
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['career-recommendation-system-jxzn.onrender.com', 'localhost', '127.0.0.1']
 
 INSTALLED_APPS = [
     'django.contrib.admin',

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ Django==5.2.1
 executing==2.2.0
 experta==1.9.4
 filelock==3.18.0
-frozendict
+frozendict>=2.0.0
 fsspec==2025.5.0
 googlesearch-python==1.3.0
 gunicorn==23.0.0


### PR DESCRIPTION
This commit addresses two issues encountered during deployment on Render:

1.  **AttributeError: module 'collections' has no attribute 'Mapping'**: This was caused by an outdated or incompatible version of `frozendict`. The `requirements.txt` file has been updated to specify `frozendict>=2.0.0`, which uses `collections.abc.Mapping` and is compatible with Python 3.10+.

2.  **DisallowedHost: Invalid HTTP_HOST header**: The Django `ALLOWED_HOSTS` setting in `career_recommendation_system/settings.py` was updated to include the Render domain `'career-recommendation-system-jxzn.onrender.com'`, as well as `'localhost'` and `'127.0.0.1'` for local development.